### PR TITLE
Prevent webauthn calls when on storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -44,4 +44,8 @@ module.exports = {
     builder: "webpack5",
   },
   staticDirs: ["../src/assets"],
+  env: (config) => ({
+    ...config,
+    ENV_NAME: 'STORYBOOK',
+  }),
 };

--- a/src/components/LoginButton/LoginButton.test.tsx
+++ b/src/components/LoginButton/LoginButton.test.tsx
@@ -18,8 +18,15 @@ jest.mock('../../assets/GrayInverted.svg', () => 'gray-inverted');
     - test custom props being respected in each component
 */
 
+const BASE_ENV = process.env;
+
 beforeEach(() => {
   jest.resetModules();
+  process.env = { ...BASE_ENV };
+});
+
+afterAll(() => {
+  process.env = BASE_ENV;
 });
 
 test("LoginButton should be defined", () => {
@@ -81,5 +88,29 @@ test("LoginButton success callback function should be called", async () => {
 
   await Promise.resolve();
   expect(loginCallback).toBeCalledTimes(1);
+  expect(errorCallback).not.toBeCalled();
+});
+
+test('Testing with ENV_NAME = STORYBOOK env variable', async () => {
+  process.env.ENV_NAME = 'STORYBOOK';
+
+  const loginCallback = jest.fn();
+  const errorCallback = jest.fn();
+
+  const { getByTestId } = render(
+    <LoginButton
+      domain="foo"
+      label="Login"
+      icon="gray-inverted"
+      skin="primary"
+      onLogin={loginCallback}
+      onError={errorCallback}
+    />
+  );
+  const loginButton = getByTestId('nebula-button');
+  fireEvent.click(loginButton);
+
+  await Promise.resolve();
+  expect(loginCallback).not.toBeCalled();
   expect(errorCallback).not.toBeCalled();
 });

--- a/src/components/LoginButton/LoginButton.tsx
+++ b/src/components/LoginButton/LoginButton.tsx
@@ -14,6 +14,8 @@ export function LoginButton(props: LoginButtonProps) {
     errorCallback: AuthenticationError
   ): MouseEventHandler<HTMLButtonElement> {
     return (_e: any) => {
+      if (process.env.ENV_NAME === 'STORYBOOK') return;
+
       startUserLogin({
         name: props.domain,
         crossOrigin: false,

--- a/src/components/RegisterButton/RegisterButton.test.tsx
+++ b/src/components/RegisterButton/RegisterButton.test.tsx
@@ -16,8 +16,15 @@ jest.mock("@sonr-io/webauthn");
     - test custom props being respected in each component
 */
 
+const BASE_ENV = process.env;
+
 beforeEach(() => {
   jest.resetModules();
+  process.env = { ...BASE_ENV };
+});
+
+afterAll(() => {
+  process.env = BASE_ENV;
 });
 
 test("RegisterButton should be defined", () => {
@@ -60,5 +67,28 @@ test("RegisterButton success callback function should be called", async () => {
 
   await Promise.resolve();
   expect(registerCallback).toBeCalledTimes(1);
+  expect(errorCallback).not.toBeCalled();
+});
+
+test('Testing with ENV_NAME = STORYBOOK env variable', async () => {
+  process.env.ENV_NAME = 'STORYBOOK';
+
+  const registerCallback = jest.fn();
+  const errorCallback = jest.fn();
+
+  const { getByTestId } = render(
+    <RegisterButton
+      domain="foo"
+      label="Login"
+      skin="primary"
+      onRegister={registerCallback}
+      onError={errorCallback}
+    />
+  );
+  const registerButton = getByTestId('nebula-button');
+  fireEvent.click(registerButton);
+
+  await Promise.resolve();
+  expect(registerCallback).not.toBeCalled();
   expect(errorCallback).not.toBeCalled();
 });

--- a/src/components/RegisterButton/RegisterButton.tsx
+++ b/src/components/RegisterButton/RegisterButton.tsx
@@ -14,6 +14,8 @@ export function RegisterButton(registerButtonProps: RegisterButtonProps) {
     errorCallback: AuthenticationError
   ): MouseEventHandler<HTMLButtonElement> {
     return (_e: any) => {
+      if (process.env.ENV_NAME === 'STORYBOOK') return;
+
       startUserRegistration({
         name: registerButtonProps.domain,
         crossOrigin: false,

--- a/src/components/RegisterForm/RegisterForm.tsx
+++ b/src/components/RegisterForm/RegisterForm.tsx
@@ -12,6 +12,8 @@ export function RegisterForm({ domain, onError, onRegister }: RegisterFormProps)
 
   function OnSubmitWrapper(event: SyntheticEvent) {
     event.preventDefault();
+    if (process.env.ENV_NAME === 'STORYBOOK') return;
+
     const callback = onRegister;
     const errorCallback = onError;
 

--- a/src/components/RegisterForm/RegistrationForm.test.tsx
+++ b/src/components/RegisterForm/RegistrationForm.test.tsx
@@ -16,8 +16,15 @@ jest.mock('@sonr-io/webauthn');
     - test custom props being respected in each component
 */
 
+const BASE_ENV = process.env;
+
 beforeEach(() => {
   jest.resetModules();
+  process.env = { ...BASE_ENV };
+});
+
+afterAll(() => {
+  process.env = BASE_ENV;
 });
 
 test('Register Form should be defined', () => {
@@ -110,5 +117,26 @@ test("RegisterForm success callback function should be called", async () => {
 
   await Promise.resolve();
   expect(registerCallback).toBeCalledTimes(1);
+  expect(errorCallback).not.toBeCalled();
+});
+
+test('Testing with ENV_NAME = STORYBOOK env variable', async () => {
+  process.env.ENV_NAME = 'STORYBOOK';
+
+  const registerCallback = jest.fn();
+  const errorCallback = jest.fn();
+
+  const { getByTestId } = render(
+    <RegisterForm
+      domain="foo"
+      onRegister={registerCallback}
+      onError={errorCallback}
+    />
+  );
+  const registerButton = getByTestId('nebula-button');
+  fireEvent.click(registerButton);
+
+  await Promise.resolve();
+  expect(registerCallback).not.toBeCalled();
   expect(errorCallback).not.toBeCalled();
 });


### PR DESCRIPTION
Prevent webauthn calls when running on storybook

## Changes

- Added `ENV_NAME` env variable on storybook main.js config file
- Verify `ENV_NAME` inside `LoginButotn`, `RegisterButton` and `RegisterForm` componentes to prevent webauthn calls

## API Updates

### New Features *(required)*

<!-- This section should include details regarding new features added to the library.
This should include both open and private APIs. If including both, create two
sub headers underneath this one to label updates accordingly. -->

### Deprecations *(required)*

<!-- All deprecations should be listed here in order to ensure the reviewer understands
which sections of the codebase will affect contributors and users of the library. -->

### Enhancements *(optional)*

<!-- The enhancements section should include code updates that were included with this
pull request. This section should detail refactoring that might have affected
other parts of the library. -->

## Checklist

- [X] Unit tests
- [ ] Documentation

## References *(optional)*

<!-- Include __important__ links regarding the implementation of this PR.
This usually includes a RFC or an aggregation of issues and/or individual conversations
that helped put this solution together. This helps ensure there is a good aggregation
of resources regarding the implementation. -->

Fixes 
Connects 


<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>